### PR TITLE
Jmprieur/command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Command line tool that creates Microsoft identity platform applications in a ten
 2. Run the following in a developer command prompt in the `src\DotnetTool` folder:
    
    ```Shell
-   dotnet tool install --global --add-source ./nupkg msIdentityApp
+   dotnet tool install --global --add-source ./nupkg ms-identity-app
    ```
 
 If later you want to uninstall the tool, just run:
 ```Shell
-dotnet tool uninstall --global msidentityapp
+dotnet tool uninstall --global ms-identity-app
 ```
 
 ## Pre-requisites to using the tool

--- a/src/DotnetTool/DotnetTool.sln
+++ b/src/DotnetTool/DotnetTool.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30523.141
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "msIdentityApp", "msIdentityApp.csproj", "{E2ABBF3D-B4C4-44ED-9BBD-3B179B7B7AE8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ms-identity-app", "ms-identity-app.csproj", "{E2ABBF3D-B4C4-44ED-9BBD-3B179B7B7AE8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "..\UnitTests\Tests.csproj", "{04F73322-3693-4A9D-BAB3-4DDD92990426}"
 EndProject

--- a/src/DotnetTool/DotnetTool.sln
+++ b/src/DotnetTool/DotnetTool.sln
@@ -9,6 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "..\UnitTests\Tests
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A19666A5-C80E-4169-B036-9D3B94E4279D}"
 	ProjectSection(SolutionItems) = preProject
+		..\..\README.md = ..\..\README.md
 		Readme.txt = Readme.txt
 	EndProjectSection
 EndProject

--- a/src/DotnetTool/Program.cs
+++ b/src/DotnetTool/Program.cs
@@ -8,46 +8,41 @@ namespace DotnetTool
     public static class Program
     {
         /// <summary>
-        /// Mapping between the command line and the ProvisionningToolOptions
+        /// Creates or updates an AzureAD/Azure AD B2C application, and updates the code, using
+        /// the developer credentials (Visual Studio, Azure CLI, Azure RM PowerShell, VS Code)
         /// </summary>
-        private static Dictionary<string, string> mapping = new Dictionary<string, string>
-            {
-                {"--folder", nameof(ProvisioningToolOptions.CodeFolder)},
-                {"--language-framework", nameof(ProvisioningToolOptions.LanguageOrFramework)},
-                {"--username", nameof(ProvisioningToolOptions.Username)},
-                {"--client-secret", nameof(ProvisioningToolOptions.ClientSecret)},
-                {"--client-id", nameof(ProvisioningToolOptions.ClientId)},
-                {"--tenant-id", nameof(ProvisioningToolOptions.TenantId)},
-                {"--project-type", nameof(ProvisioningToolOptions.ProjectType)},
-                {"--unregister", nameof(ProvisioningToolOptions.Unregister)},
-            };
-   
-        static public async Task Main(string[] args)
+        /// <param name="tenantId">Azure AD or Azure AD B2C tenant in which to create/update the app. By default
+        /// this will be your home tenant ID</param>
+        /// <param name="username">Username to use to connect to the Azure AD or Azure AD B2C tenant.
+        /// By default this will be your home user id</param>
+        /// <param name="folder">Folder in which to look at the code. By default the current folder</param>
+        /// <param name="clientId">Client ID of an existing application from which to update the code.</param>
+        /// <param name="clientSecret">Client secret to use as a client credential</param>
+        /// <param name="unregister">Unregister the application, instead of registering it</param>
+        /// <returns></returns>
+        static public async Task Main(
+            string tenantId = null,
+            string username = null,
+            string clientId = null,
+            bool unregister = false,
+            string folder = null,
+            string clientSecret = null)
         {
             // Read options
-            ProvisioningToolOptions provisioningToolOptions = GetOptions(args);
+            ProvisioningToolOptions provisioningToolOptions = new ProvisioningToolOptions
+            {
+                Username = username,
+                ClientId = clientId,
+                ClientSecret = clientSecret,
+                TenantId = tenantId
+            };
+            if (folder!=null)
+            {
+                provisioningToolOptions.CodeFolder = folder;
+            }
 
             AppProvisionningTool appProvisionningTool = new AppProvisionningTool(provisioningToolOptions);
             await appProvisionningTool.Run();
-        }
-
-        /// <summary>
-        /// Get the options from the command line
-        /// </summary>
-        /// <param name="args">Command line arguments</param>
-        /// <returns>Provisionning tool options</returns>
-        private static ProvisioningToolOptions GetOptions(string[] args)
-        {
-            ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
-            configurationBuilder.AddCommandLine(args, mapping);
-            IConfiguration configuration = configurationBuilder.Build();
-            ProvisioningToolOptions provisioningToolOptions = new ProvisioningToolOptions();
-            ConfigurationBinder.Bind(configuration, provisioningToolOptions);
-
-            bool help = args.Any(arg => !arg.StartsWith("--help"));
-            provisioningToolOptions.Help = help;
-
-            return provisioningToolOptions;
         }
 
         public static void GenerateTests()

--- a/src/DotnetTool/ProjectDescription/ProjectDescriptionReader.cs
+++ b/src/DotnetTool/ProjectDescription/ProjectDescriptionReader.cs
@@ -121,7 +121,7 @@ namespace DotnetTool.Project
                 return;
             }
 
-            var properties = typeof(msIdentityApp.Properties.Resources).GetProperties(BindingFlags.Static | BindingFlags.NonPublic)
+            var properties = typeof(Microsoft.Identity.App.Properties.Resources).GetProperties(BindingFlags.Static | BindingFlags.NonPublic)
                 .Where(p => p.PropertyType == typeof(byte[]))
                 .ToArray();
             foreach (PropertyInfo propertyInfo in properties)

--- a/src/DotnetTool/Properties/Resources.Designer.cs
+++ b/src/DotnetTool/Properties/Resources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace msIdentityApp.Properties {
+namespace Microsoft.Identity.App.Properties {
     using System;
     
     
@@ -39,7 +39,7 @@ namespace msIdentityApp.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("msIdentityApp.Properties.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Identity.App.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/DotnetTool/Properties/launchSettings.json
+++ b/src/DotnetTool/Properties/launchSettings.json
@@ -1,5 +1,10 @@
 {
   "profiles": {
+    "DotnetTool from demo folder": {
+      "commandName": "Project",
+      "commandLineArgs": "",
+      "workingDirectory": "C:\\Users\\jmprieur\\demo"
+    },
     "DotnetTool-webapp calls graph": {
       "commandName": "Project",
       "commandLineArgs": "--tenant-id testprovisionningtool.onmicrosoft.com",

--- a/src/DotnetTool/ms-identity-app.csproj
+++ b/src/DotnetTool/ms-identity-app.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <RootNamespace>Microsoft.Identity.App</RootNamespace>
     
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>ms-identity-app</ToolCommandName>
@@ -39,6 +40,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.9" />
     <PackageReference Include="Microsoft.Graph" Version="3.20.0" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.16.5" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20574.7" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 

--- a/src/DotnetTool/ms-identity-app.csproj.user
+++ b/src/DotnetTool/ms-identity-app.csproj.user
@@ -2,7 +2,7 @@
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ShowAllFiles>false</ShowAllFiles>
-    <ActiveDebugProfile>webapp-from-existing-app</ActiveDebugProfile>
+    <ActiveDebugProfile>DotnetTool from demo folder</ActiveDebugProfile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/src/UnitTests/CleanUp.cs
+++ b/src/UnitTests/CleanUp.cs
@@ -61,16 +61,8 @@ namespace Tests
             {
                 Directory.SetCurrentDirectory(folderToCreate);
 
-                List<string> args = new List<string>();
-                if (folder.Contains("b2c"))
-                {
-                    args.Add("--tenant-id");
-                    args.Add("fabrikamb2c.onmicrosoft.com");
-                }
-                args.Add("--unregister");
-                args.Add("true");
-
-                await Program.Main(args.ToArray());
+                string tenantId = folder.Contains("b2c") ? "fabrikamb2c.onmicrosoft.com" : null;
+                await Program.Main(tenantId: tenantId, unregister:true);
             }
             finally
             {

--- a/src/UnitTests/E2ETests.cs
+++ b/src/UnitTests/E2ETests.cs
@@ -84,18 +84,10 @@ namespace Tests
             try
             {
                 Directory.SetCurrentDirectory(folderToCreate);
-
-                List<string> args = new List<string>();
-                args.Add("--tenant-id");
-                if (folder.Contains("b2c"))
-                {
-                    args.Add("fabrikamb2c.onmicrosoft.com");
-                }
-                else
-                {
-                    args.Add("testprovisionningtool.onmicrosoft.com");
-                }
-                await Program.Main(args.ToArray());
+                string tenantId = folder.Contains("b2c") ?
+                    "fabrikamb2c.onmicrosoft.com" :
+                    "testprovisionningtool.onmicrosoft.com";
+                await Program.Main(tenantId:tenantId);
             }
             catch (Exception ex)
             {
@@ -197,17 +189,11 @@ namespace Tests
             {
                 Directory.SetCurrentDirectory(folderToCreate);
 
-                List<string> args = new List<string>();
-                args.Add("--tenant-id");
-                if (folder.Contains("b2c"))
-                {
-                    args.Add("fabrikamb2c.onmicrosoft.com");
-                }
-                else
-                {
-                    args.Add("testprovisionningtool.onmicrosoft.com");
-                }
-                await Program.Main(args.ToArray());
+                Directory.SetCurrentDirectory(folderToCreate);
+                string tenantId = folder.Contains("b2c") ?
+                    "fabrikamb2c.onmicrosoft.com" :
+                    "testprovisionningtool.onmicrosoft.com";
+                await Program.Main(tenantId: tenantId);
             }
             catch (Exception ex)
             {

--- a/src/UnitTests/Tests.csproj
+++ b/src/UnitTests/Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\DotnetTool\msIdentityApp.csproj" />
+    <ProjectReference Include="..\DotnetTool\ms-identity-app.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #12 
and renames the name of the nuget package to be the same as the tool

Now it's possible to run:
```Shell
ms-identity-app --help
```

 and get the full help:

```text
ms-identity-app:
  Creates or updates an AzureAD/Azure AD B2C application, and updates the code, using
   the developer credentials (Visual Studio, Azure CLI, Azure RM PowerShell, VS Code)

Usage:
  ms-identity-app [options]

Options:
  --tenant-id <tenant-id>            Azure AD or Azure AD B2C tenant in which to create/update the app. By default
                                      this will be your home tenant ID [default: ]
  --username <username>              Username to use to connect to the Azure AD or Azure AD B2C tenant.
                                      By default this will be your home user id [default: ]
  --client-id <client-id>            Client ID of an existing application from which to update the code. [default: ]
  --unregister                       Unregister the application, instead of registering it [default: False]
  --folder <folder>                  Folder in which to look at the code. By default the current folder [default: ]
  --client-secret <client-secret>    Client secret to use as a client credential [default: ]
  --version                          Show version information
  -?, -h, --help                     Show help and usage information
```

If you use PowerShell, or Bash, you can also get the completion if you install [dotnet-suggest](https://www.nuget.org/packages/dotnet-suggest/). See https://github.com/dotnet/command-line-api/blob/main/docs/dotnet-suggest.md